### PR TITLE
Fixed migrations by adding DesignTimeDbContextFactory

### DIFF
--- a/CourseStream/CourseStream.Data/CourseStreamDBContext.cs
+++ b/CourseStream/CourseStream.Data/CourseStreamDBContext.cs
@@ -1,4 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
 namespace CourseStream.Data;
 
 public class CourseStreamDbContext : DbContext
@@ -9,5 +11,16 @@ public class CourseStreamDbContext : DbContext
     public CourseStreamDbContext(DbContextOptions options)
         : base(options)
     {
+    }
+    // Design factory for migrations
+    public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<CourseStreamDbContext>
+    {
+        public CourseStreamDbContext CreateDbContext(string[] args)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<CourseStreamDbContext>();
+            optionsBuilder.UseNpgsql("Host=postgres; Database=Identity; User Id=identityuser; Password=identityuser; Port=5432");
+
+            return new CourseStreamDbContext(optionsBuilder.Options);
+        }
     }
 }

--- a/CourseTemplate/CourseTemplate.Data/CourseTemplateDbContext.cs
+++ b/CourseTemplate/CourseTemplate.Data/CourseTemplateDbContext.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
 
 namespace CourseTemplate.Data;
 
@@ -9,6 +10,17 @@ public class CourseTemplateDbContext : DbContext
 		: base(options)
 	{
 	}
+        // Design factory for migrations
+        public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<CourseTemplateDbContext>
+        {
+            public CourseTemplateDbContext CreateDbContext(string[] args)
+            {
+                var optionsBuilder = new DbContextOptionsBuilder<CourseTemplateDbContext>();
+                optionsBuilder.UseNpgsql("Host=postgres; Database=Identity; User Id=identityuser; Password=identityuser; Port=5432");
+    
+                return new CourseTemplateDbContext(optionsBuilder.Options);
+            }
+        }
 	
 }
 

--- a/Identity/Identity.Data/IdentityDbContext.cs
+++ b/Identity/Identity.Data/IdentityDbContext.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
 
 namespace Identity.Data;
 
@@ -10,6 +11,19 @@ public class IdentityDbContext : DbContext
         : base(options)
     {
     }
+    
+    // Design factory for migrations
+    public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<IdentityDbContext>
+    {
+        public IdentityDbContext CreateDbContext(string[] args)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<IdentityDbContext>();
+            optionsBuilder.UseNpgsql("Host=postgres; Database=Identity; User Id=identityuser; Password=identityuser; Port=5432");
+
+            return new IdentityDbContext(optionsBuilder.Options);
+        }
+    }
+
 }
 
 public class User

--- a/Materials/Materials.Data/MaterialsDbContext.cs
+++ b/Materials/Materials.Data/MaterialsDbContext.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
 
 namespace Materials.Data;
 
@@ -10,5 +11,16 @@ public class MaterialsDbContext : DbContext
     public MaterialsDbContext(DbContextOptions options)
         : base(options)
     {
+    }
+    // Design factory for migrations
+    public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<MaterialsDbContext>
+    {
+        public MaterialsDbContext CreateDbContext(string[] args)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<MaterialsDbContext>();
+            optionsBuilder.UseNpgsql("Host=postgres; Database=Identity; User Id=identityuser; Password=identityuser; Port=5432");
+
+            return new MaterialsDbContext(optionsBuilder.Options);
+        }
     }
 }


### PR DESCRIPTION
Closes #171 
**Here is the results:**
```shell
PS D:\C#\AcademicHub\Identity\Identity.Data> dotnet ef migrations add Test                        
Build started...
Build succeeded.
Done. To undo this action, use 'ef migrations remove'

``` 

**Here is logs from docker:**
![image](https://github.com/AcademicHubOrg/AcademicHub/assets/94047397/60265666-3a99-4ea7-8460-5af1e6abfbc2)

@Bardin08 For some reason I can't commit migrations. However, they are created. Here is the screenshot:
![image](https://github.com/AcademicHubOrg/AcademicHub/assets/94047397/0901c136-73e7-49cc-b4da-27e20f4c19dd)

@Bardin08  By the way, you can't undo migrations by running the command dotnet ef migrations remove. This is because the postgres sql is running inside docker container and have no port for outside world. Should we then delete them manually?
